### PR TITLE
Allow use of stable rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
    - RUST_BACKTRACE=1
 
 rust:
-  - nightly
+  - stable
 
 matrix:
   fast_finish: true
@@ -22,4 +22,3 @@ script:
   - cargo build
   - cargo build --example stm32l0x2
   #  - cargo fmt -- --check
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,3 @@
 ## Code Status
 
 [![Build Status](https://travis-ci.com/helium/longfi-device.svg?token=35YrBmyVB8LNrXzjrRop&branch=master)](https://travis-ci.com/helium/longfi-device-rs)
-
-## Notes
-
-Due to `#![feature(rustc_private)]` in `longfi-sys/build.rs`, requires nightly.

--- a/examples/stm32l0x2/main.rs
+++ b/examples/stm32l0x2/main.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(lang_items)]
 
 /*
 /*!

--- a/longfi-sys/Cargo.toml
+++ b/longfi-sys/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 
 [build-dependencies]
 bindgen = {version="=0.49.0", default-features = false }
+cc = "1.0"
 
 [dependencies]
 cty =  "0.2"

--- a/longfi-sys/build.rs
+++ b/longfi-sys/build.rs
@@ -1,7 +1,5 @@
-#![feature(rustc_private)]
-extern crate cc;
-
 use bindgen;
+use cc;
 use std::env;
 use std::path::PathBuf;
 use std::process::Command;


### PR DESCRIPTION
This project currently requires nightly for two reasons:

1. The use of unstable feature `rustc_private` in
   `longfi-sys/build.rs`
2. Use of unstable feature `lang_items` in
   `examples/stm32l0x2/main.rs`

Neither one is required.

(1) _was_ necessary because `longfi-sys/Cargo.toml` did not delcare
`cc` as a depdendency. As a result, the compiler assumed that we
wanted `rustc`'s own `cc` crate. Direct use of Rust's internal
dependencies is an unstalbe feature and does require `rustc_private`.

(2) was not needed at all, and is likeley just a result of starting
with an outdated RTFM example, as RTFM one did require `lang_items`
but removed the need sometime in 2018.