### PR TITLE
improve submodule path so it works from cargo client

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "longfi-sys/longfi-device"]
 	path = longfi-sys/longfi-device
-	url = ssh://github.com/helium/longfi-device.git
+	url = https://github.com/helium/longfi-device.git


### PR DESCRIPTION
A client project that uses longfi-device over cargo package manager could not clone the submodule properly.