### PR TITLE
improve submodule path so that it works from cargo client

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "longfi-sys/longfi-device"]
 	path = longfi-sys/longfi-device
-	url = git@github.com:helium/longfi-device.git
+	url = ssh://git@github.com/helium/longfi-device.git


### PR DESCRIPTION
A client project that uses longfi-device over cargo package manager could not clone the submodule properly.

I think I got it this time.