### PR TITLE
Add workaround for cargo bug 5730

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 target/
 **/*.rs.bk
-Cargo.lock
+*.lock
 *.hex
 *.bin
 
+build-script-target

--- a/longfi-sys/Cargo.toml
+++ b/longfi-sys/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 build = "build.rs"
 
 [build-dependencies]
+cargo-5730 = "0.2"
+
+[workaround-build-dependencies]
 bindgen = {version="=0.49.0", default-features = false }
 cc = "1.0"
 

--- a/longfi-sys/build.rs
+++ b/longfi-sys/build.rs
@@ -1,10 +1,9 @@
-use bindgen;
-use cc;
-use std::env;
-use std::path::PathBuf;
-use std::process::Command;
-
+#[cfg(workaround_build)]
 fn main() {
+    use std::env;
+    use std::path::PathBuf;
+    use std::process::Command;
+
     // build `libloragw`
     Command::new("make")
         .args(&["-C ", "longfi-device/radio/sx1276"])
@@ -96,4 +95,9 @@ fn main() {
         .file("longfi-device/longfi.c")
         .file("longfi-device/radio/sx1276/sx1276.c")
         .compile("longfi-device");
+}
+
+#[cfg(not(workaround_build))]
+fn main() {
+    cargo_5730::run_build_script();
 }


### PR DESCRIPTION
This PR adds a workaround for a cargo bug. The bus is that cargo sometimes doesn't honor dependent crates' feature flags when those same crates are used in build scripts (and procedural macros?). In order to use `nom` Helios, we had to turn off default features, but a transitive build-time dependency of this also used nom and prevented helios of compiling. 

helium/helios#13 was merged too soon (it was marked as WIP), helios master currently depends on this branch. What needs to be done is:

1. merge this branch
2. update `helios` to point at this crate's master branch
3. delete this branch

... in exactly that order.