### PR TITLE
Actually abort when the sx1276 build fails

### DIFF
--- a/longfi-sys/build.rs
+++ b/longfi-sys/build.rs
@@ -5,10 +5,11 @@ fn main() {
     use std::process::Command;
 
     // build `libloragw`
-    Command::new("make")
+    let status = Command::new("make")
         .args(&["-C ", "longfi-device/radio/sx1276"])
         .status()
-        .expect("sx1276 build failed");
+        .expect("failed to execute make");
+    assert!(status.success(), "sx1276 build failed");
 
     let radio_path =
         PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("longfi-device/radio/");


### PR DESCRIPTION
...actually this could have never worked since there's no Makefile in that directory, so don't merge this. Can someone explain what this was supposed to do?