### PR TITLE
LongFi fingerprint bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ Bug fixes:
 * [Link to github PR]():
   A bugfix.
 -->
-
+0.1.1 (2019-11-13)
+==================
+Fixed bug where fingerprints failed due to memory misalignment with C bindings
 
 0.1.0 (2019-10-28)
 ==================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "longfi-device"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Louis Thiery <louis@helium.com>"]
 edition = "2018"
 categories = [

--- a/examples/stm32l0x2/main.rs
+++ b/examples/stm32l0x2/main.rs
@@ -20,6 +20,8 @@ pub use longfi_bindings::LongFiBindings;
 pub use longfi_bindings::RadioIRQ;
 pub use longfi_bindings::TcxoEn;
 
+const OUI: u32 = 1;
+const DEVICE_ID: u32 = 5;
 const PRESHARED_KEY: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
 #[rtfm::app(device = stm32l0xx_hal::pac)]
@@ -79,8 +81,8 @@ const APP: () = {
         ));
 
         let rf_config = Config {
-            oui: 1234,
-            device_id: 5678,
+            oui: OUI,
+            device_id: DEVICE_ID,
             auth_mode: longfi_device::AuthMode::PresharedKey128,
         };
 

--- a/examples/stm32l0x2/main.rs
+++ b/examples/stm32l0x2/main.rs
@@ -21,7 +21,7 @@ pub use longfi_bindings::RadioIRQ;
 pub use longfi_bindings::TcxoEn;
 
 const OUI: u32 = 1;
-const DEVICE_ID: u32 = 5;
+const DEVICE_ID: u16 = 5;
 const PRESHARED_KEY: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
 #[rtfm::app(device = stm32l0xx_hal::pac)]


### PR DESCRIPTION
This bumps the longfi-device submodule version to absorb [the enum definition fix])(https://github.com/helium/longfi-device/pull/23). 

Previously, memory was misaligned which was causing fingerprinting to fail.