### PR TITLE
Help Rust only include a single Radio

### DIFF
--- a/examples/stm32l0x2/main.rs
+++ b/examples/stm32l0x2/main.rs
@@ -11,7 +11,7 @@ use core::fmt::Write;
 use hal::serial::USART2 as DebugUsart;
 use hal::{pac, prelude::*, rcc, rng::Rng, serial, syscfg};
 use longfi_device;
-use longfi_device::{ClientEvent, Config, LongFi, RadioType, RfEvent};
+use longfi_device::{Radio, ClientEvent, Config, LongFi, RfEvent};
 use stm32l0xx_hal as hal;
 
 mod longfi_bindings;
@@ -87,13 +87,15 @@ const APP: () = {
 
         let mut longfi_radio;
         if let Some(bindings) = BINDINGS {
-            longfi_radio = LongFi::new(
-                RadioType::Sx1276,
-                &mut bindings.bindings,
-                rf_config,
-                &PRESHARED_KEY,
-            )
-            .unwrap();
+            longfi_radio = unsafe {
+                LongFi::new(
+                    Radio::sx1276(),
+                    &mut bindings.bindings,
+                    rf_config,
+                    &PRESHARED_KEY,
+                )
+                .unwrap()
+            };
         } else {
             panic!("No bindings exist");
         }

--- a/examples/stm32l0x2/main.rs
+++ b/examples/stm32l0x2/main.rs
@@ -11,7 +11,7 @@ use core::fmt::Write;
 use hal::serial::USART2 as DebugUsart;
 use hal::{pac, prelude::*, rcc, rng::Rng, serial, syscfg};
 use longfi_device;
-use longfi_device::{Radio, ClientEvent, Config, LongFi, RfEvent};
+use longfi_device::{ClientEvent, Config, LongFi, Radio, RfEvent};
 use stm32l0xx_hal as hal;
 
 mod longfi_bindings;

--- a/examples/stm32l0x2/main.rs
+++ b/examples/stm32l0x2/main.rs
@@ -88,12 +88,12 @@ const APP: () = {
         let mut longfi_radio;
         if let Some(bindings) = BINDINGS {
             longfi_radio = LongFi::new(
-                    Radio::sx1276(),
-                    &mut bindings.bindings,
-                    rf_config,
-                    &PRESHARED_KEY,
-                )
-                .unwrap()
+                Radio::sx1276(),
+                &mut bindings.bindings,
+                rf_config,
+                &PRESHARED_KEY,
+            )
+            .unwrap()
         } else {
             panic!("No bindings exist");
         }

--- a/examples/stm32l0x2/main.rs
+++ b/examples/stm32l0x2/main.rs
@@ -87,15 +87,13 @@ const APP: () = {
 
         let mut longfi_radio;
         if let Some(bindings) = BINDINGS {
-            longfi_radio = unsafe {
-                LongFi::new(
+            longfi_radio = LongFi::new(
                     Radio::sx1276(),
                     &mut bindings.bindings,
                     rf_config,
                     &PRESHARED_KEY,
                 )
                 .unwrap()
-            };
         } else {
             panic!("No bindings exist");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,13 +32,13 @@ pub struct Radio {
 }
 
 impl Radio {
-    pub fn new_sx1262() -> Radio {
+    pub fn sx1262() -> Radio {
         Radio {
             c_handle: unsafe{ SX126xRadioNew() }
         }
     }
 
-    pub fn new_sx1276() -> Radio {
+    pub fn sx1276() -> Radio {
         Radio {
             c_handle: unsafe { SX1276RadioNew() }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,23 +28,22 @@ pub enum Error {
 unsafe impl Send for LongFi {}
 
 pub struct Radio {
-    c_handle: Radio_t
+    c_handle: Radio_t,
 }
 
 impl Radio {
     pub fn sx1262() -> Radio {
         Radio {
-            c_handle: unsafe{ SX126xRadioNew() }
+            c_handle: unsafe { SX126xRadioNew() },
         }
     }
 
     pub fn sx1276() -> Radio {
         Radio {
-            c_handle: unsafe { SX1276RadioNew() }
+            c_handle: unsafe { SX1276RadioNew() },
         }
     }
 }
-
 
 impl LongFi {
     pub fn new(


### PR DESCRIPTION
Drivers for both radios (SX1262 and SX1276) are being included. This unfortunately changes the API but coerces the compiler into only including one of the radios.